### PR TITLE
Add DKIM Location

### DIFF
--- a/files/google-workspace.txt
+++ b/files/google-workspace.txt
@@ -25,4 +25,4 @@
 
 ;; DKIM
 ;; - YOU MUST CHANGE THIS
-google._domainkey 300 IN TXT "CHANGE THIS WITH YOUR DKIM"
+google._domainkey 300 IN TXT "CHANGE THIS WITH YOUR DKIM YOU CAN GET IT HERE https://admin.google.com/ac/apps/gmail/authenticateemail"


### PR DESCRIPTION
Just went through this with a client. Having a direct link to set up DKIM is helpful, most already have their site verified but I can create a separate pull request for that.

Question: would it be better to link to a help article such as https://support.google.com/a/answer/174126 or do you think straight to the admin console is better?